### PR TITLE
Fix clean_string pipeline

### DIFF
--- a/R/utils-clean.R
+++ b/R/utils-clean.R
@@ -1,7 +1,17 @@
-clean_string <- function(x){
+clean_string <- function(x) {
+  if (!is.character(x)) {
+    stop("Input must be a character string.")
+  }
+  if (length(x) == 0) {
+    return("")
+  }
+  if (is.na(x)) {
+    return(NA_character_)
+  }
+
   x |>
     stringi::stri_trans_general("Latin-ASCII") |>
     tolower() |>
-    gsub("[^a-z0-9\\s]", " ", x = _) |>
+    (\(s) gsub("[[:punct:]]", " ", s))() |>
     stringr::str_squish()
 }


### PR DESCRIPTION
## Summary
- fix `clean_string` in utils to avoid placeholder bug

## Testing
- `Rscript -e 'print("hello")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846cdc71d848320b73adec7625dce30